### PR TITLE
Three small bugs regarding prompt with type int

### DIFF
--- a/navigator/ui.py
+++ b/navigator/ui.py
@@ -60,7 +60,7 @@ def prompt(message, expected_type='str', default=None):
         raw = _prompt_for_input(message)
         if default is not None and not raw:
             raw = default
-        if raw and expected_type == 'int':
+        if (raw or raw == 0)and expected_type == 'int':
             try:
                 return int(raw)
             except ValueError:

--- a/navigator/ui.py
+++ b/navigator/ui.py
@@ -91,6 +91,8 @@ def choice(message, choices, default=None):
             text_prompt("  {} - {}".format(i, choice[0]))
         picked = prompt(message, "int", default)
         try:
+            if picked < 0:
+                raise IndexError()
             return choices[picked][1]
         except IndexError:
             text_error("That is not a valid selection")

--- a/navigator/ui.py
+++ b/navigator/ui.py
@@ -54,9 +54,9 @@ def text_error(message, end="\n"):
 # User Input
 #-----------------------------------------------------------------------------#
 def prompt(message, expected_type='str', default=None):
+    if default is not None:
+        message += " [Default: {}]".format(default)
     while True:
-        if default is not None:
-            message += " [Default: {}]".format(default)
         raw = _prompt_for_input(message)
         if default is not None and not raw:
             raw = default


### PR DESCRIPTION
One of them I have introduced, apologies.
1. Invalid input got the default message concatenation repeated
2. Default value of valid option 0 wasn't working.
3. Negative value could be accepted as valid.

Also, sorry for having inconvenienced you already for a release (and hopefully now again). Unfortunately such is the nature of bugs, to be discovered when least convenient.
Meantime I've been using and testing these changes and the usage of the library in general, so I'm hopeful not to find any more bugs. :)